### PR TITLE
make print_format example compile

### DIFF
--- a/print_format/components/rust/src/lib.rs
+++ b/print_format/components/rust/src/lib.rs
@@ -15,6 +15,9 @@ extern "C" {
 }
 
 // Stdout struct 
+use core::fmt;
+use core::fmt::Write;
+struct Stdout;
 impl fmt::Write for Stdout {
     // Implement write_str to write out a formatted string to stdout.
     fn write_str(&mut self, s: &str) -> fmt::Result {


### PR DESCRIPTION
Thanks for making these examples. I found these through your presentation at https://www.slideshare.net/ciniml/m5stackrust . It has given me hope because you have the same dev-kit as me.

Your hello_world example is the first rust code that I have run on my dev board 😄.

I still haven't made the guruguru_rust example compile, because my nightly compiler is a bit newer than yours and I'm compiling on osx, but I will try again next week.